### PR TITLE
Implement Oauth

### DIFF
--- a/.github/workflows/continuous_production.yml
+++ b/.github/workflows/continuous_production.yml
@@ -54,13 +54,11 @@ jobs:
           aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile dont-slack-evil-hackaton
       - name: Create secrets file
         run: |
-          echo "SLACK_OAUTH_ACCESS_TOKEN: $SLACK_OAUTH_ACCESS_TOKEN" >> secrets.dev.yml
           echo "SLACK_BOT_USER_OAUTH_ACCESS_TOKEN: $SLACK_BOT_USER_OAUTH_ACCESS_TOKEN" >> secrets.dev.yml
           echo "SLACK_VERIFICATION_TOKEN: $SLACK_VERIFICATION_TOKEN" >> secrets.dev.yml
           echo "PD_API_URL: $PD_API_URL" >> secrets.dev.yml
           echo "PD_API_KEY: $PD_API_KEY" >> secrets.dev.yml
         env:
-          SLACK_OAUTH_ACCESS_TOKEN: ${{ secrets.SLACK_OAUTH_ACCESS_TOKEN }}
           SLACK_BOT_USER_OAUTH_ACCESS_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           SLACK_VERIFICATION_TOKEN: ${{ secrets.SLACK_VERIFICATION_TOKEN }}
           PD_API_URL: ${{ secrets.PD_API_URL }}

--- a/.github/workflows/continuous_production.yml
+++ b/.github/workflows/continuous_production.yml
@@ -54,11 +54,15 @@ jobs:
           aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY --profile dont-slack-evil-hackaton
       - name: Create secrets file
         run: |
+          echo "CLIENT_ID: $CLIENT_ID" >> secrets.dev.yml
+          echo "CLIENT_SECRET: $CLIENT_SECRET" >> secrets.dev.yml
           echo "SLACK_BOT_USER_OAUTH_ACCESS_TOKEN: $SLACK_BOT_USER_OAUTH_ACCESS_TOKEN" >> secrets.dev.yml
           echo "SLACK_VERIFICATION_TOKEN: $SLACK_VERIFICATION_TOKEN" >> secrets.dev.yml
           echo "PD_API_URL: $PD_API_URL" >> secrets.dev.yml
           echo "PD_API_KEY: $PD_API_KEY" >> secrets.dev.yml
         env:
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           SLACK_BOT_USER_OAUTH_ACCESS_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           SLACK_VERIFICATION_TOKEN: ${{ secrets.SLACK_VERIFICATION_TOKEN }}
           PD_API_URL: ${{ secrets.PD_API_URL }}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ build:
 	env GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o bin/hello lambda/hello/hello.go
 	env GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o bin/dynamodbexample lambda/dynamodbexample/dynamodbexample.go
 	env GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o bin/messages lambda/messages/messages.go
+	env GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o bin/redirectUrl lambda/redirectUrl/redirectUrl.go
 
 clean:
 	rm -rf ./bin

--- a/example.secrets.dev.yml
+++ b/example.secrets.dev.yml
@@ -1,3 +1,6 @@
+# See app credentials here: https://api.slack.com/apps/AU7RW3DLG/general?
+CLIENT_ID: null
+CLIENT_SECRET: null
 # This token is used by the "bot user" of the SLack app (mainly when posting messages as a bot) - starts with xoxb
 # @example xoxb-424257324242-948425184242-edOs4242xwtNVIFzXij4242X
 SLACK_BOT_USER_OAUTH_ACCESS_TOKEN: null

--- a/example.secrets.dev.yml
+++ b/example.secrets.dev.yml
@@ -1,6 +1,3 @@
-# Oauth2 token for the Slack APIs (mainly used for reads) - starts with xoxp
-# @example xoxp-424257324242-424263014242-424239145348-b4242d2a6b6fd6df19ba0eaa0c0c3f3a
-SLACK_OAUTH_ACCESS_TOKEN: null
 # This token is used by the "bot user" of the SLack app (mainly when posting messages as a bot) - starts with xoxb
 # @example xoxb-424257324242-948425184242-edOs4242xwtNVIFzXij4242X
 SLACK_BOT_USER_OAUTH_ACCESS_TOKEN: null

--- a/lambda/redirectUrl/redirectUrl.go
+++ b/lambda/redirectUrl/redirectUrl.go
@@ -28,7 +28,7 @@ type OauthAccessResponse struct {
 		ID string `json:"id"`
 		Name string `json:"name"`
 	} `json:"team"`
-	Entreprise string `json:"entreprise"`
+	Enterprise string `json:"enterprise"`
 }
 
 // OauthTokenDBItem is the struct for storing the access token in DB

--- a/lambda/redirectUrl/redirectUrl.go
+++ b/lambda/redirectUrl/redirectUrl.go
@@ -42,12 +42,13 @@ type Response events.APIGatewayProxyResponse
 // Request is of type APIGatewayProxyRequest
 type Request events.APIGatewayProxyRequest
 
-// Handler is our lambda handler invoked by the `lambda.Start` function call
+// Handler is called as part of step 2 of this Oauth flow:
+// https://api.slack.com/docs/oauth
 func Handler(request Request) (Response, error) {
 	structs.DefaultTagName = "json" // https://github.com/fatih/structs/issues/25
 	var statusCode int;
 	statusCode = 302;
-	// Get Oauth Access token
+	// Step 3 - Exchanging a verification code for an access token
 	query := request.QueryStringParameters
 	code := query["code"]
 	clientID := os.Getenv("CLIENT_ID")
@@ -75,7 +76,7 @@ func Handler(request Request) (Response, error) {
 		statusCode = 500
 	}
 
-	// Save in DB
+	// Save Access token in DynamoDB
 	tableName := os.Getenv("DYNAMODB_TABLE_PREFIX") + "teams"
 	dbError := dsedb.CreateTableIfNotCreated(tableName, "slack_team_id")
 	if dbError {

--- a/lambda/redirectUrl/redirectUrl.go
+++ b/lambda/redirectUrl/redirectUrl.go
@@ -80,7 +80,6 @@ func Handler(request Request) (Response, error) {
 	dbError := dsedb.CreateTableIfNotCreated(tableName, "slack_team_id")
 	if dbError {
 		log.Println(dbError)
-		statusCode = 500
 	}
 	dbItem := dsedb.Team{
 		SlackTeamId: oauthAccessResponse.Team.ID,

--- a/lambda/redirectUrl/redirectUrl.go
+++ b/lambda/redirectUrl/redirectUrl.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"log"
-	"os"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
-	"io/ioutil"
-	"encoding/json"
 
 	dsedb "dont-slack-evil/db"
 
@@ -72,14 +72,14 @@ func Handler(request Request) (Response, error) {
 	}
 
 	// Save in DB
-	tableName := os.Getenv("DYNAMODB_TABLE_PREFIX") + "oauth-tokens"
-	dbError := dsedb.CreateTableIfNotCreated(tableName, "team_id")
+	tableName := os.Getenv("DYNAMODB_TABLE_PREFIX") + "teams"
+	dbError := dsedb.CreateTableIfNotCreated(tableName, "slack_team_id")
 	if dbError {
 		log.Println(dbError)
 	}
-	dbItem := OauthTokenDBItem{
-		TeamID: oauthAccessResponse.Team.ID,
-		AccessToken: oauthAccessResponse.AccessToken,
+	dbItem := dsedb.Team{
+		SlackTeamId: oauthAccessResponse.Team.ID,
+		SlackBotUserToken: oauthAccessResponse.AccessToken,
 	}
 	dbResult := dsedb.Store(tableName, structs.Map(&dbItem))
 	if !dbResult {

--- a/lambda/redirectUrl/redirectUrl.go
+++ b/lambda/redirectUrl/redirectUrl.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"log"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	// "dont-slack-evil/messages/service"
+	// "github.com/fatih/structs"
+
+)
+
+// Response is of type APIGatewayProxyResponse
+type Response events.APIGatewayProxyResponse
+
+// Request is of type APIGatewayProxyRequest
+type Request events.APIGatewayProxyRequest
+
+// Handler is our lambda handler invoked by the `lambda.Start` function call
+func Handler(request Request) (Response, error) {
+	body := []byte(request.Body)
+	query := request.QueryStringParameters
+	log.Printf("Receiving request body %s", body)
+	log.Printf("Receiving request query string %s", query)
+	redirectUrl := "http://lol.com"
+	resp := Response{
+		StatusCode: 200,
+		Body: redirectUrl,
+		// StatusCode: 302,
+		// Headers: map[string]string{
+		// 	"Location": redirectUrl,
+		// },
+		// Body: "",
+	}
+	return resp, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/lambda/redirectUrl/redirectUrl.go
+++ b/lambda/redirectUrl/redirectUrl.go
@@ -2,14 +2,31 @@ package main
 
 import (
 	"log"
+	"os"
+	"net/http"
+	"net/url"
+	"strings"
+	"io/ioutil"
+	"encoding/json"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	// "dont-slack-evil/messages/service"
-	// "github.com/fatih/structs"
-
 )
 
+// OauthAccessResponse is the type of the Oauth Access response
+type OauthAccessResponse struct {
+	Ok bool `json:"ok"`
+	AppID string `json:"app_id"`
+	Scope string `json:"scope"`
+	TokenType string `json:"token_type"`
+	AccessToken string `json:"access_token"`
+	BotUserID string `json:"bot_user_id"`
+	Team struct {
+		ID string `json:"id"`
+		Name string `json:"name"`
+	} `json:"team"`
+	Entreprise string `json:"entreprise"`
+}
 // Response is of type APIGatewayProxyResponse
 type Response events.APIGatewayProxyResponse
 
@@ -18,21 +35,43 @@ type Request events.APIGatewayProxyRequest
 
 // Handler is our lambda handler invoked by the `lambda.Start` function call
 func Handler(request Request) (Response, error) {
-	body := []byte(request.Body)
 	query := request.QueryStringParameters
-	log.Printf("Receiving request body %s", body)
-	log.Printf("Receiving request query string %s", query)
-	redirectUrl := "http://lol.com"
-	resp := Response{
-		StatusCode: 200,
-		Body: redirectUrl,
-		// StatusCode: 302,
-		// Headers: map[string]string{
-		// 	"Location": redirectUrl,
-		// },
-		// Body: "",
+	code := query["code"]
+	clientID := os.Getenv("CLIENT_ID")
+	clientSecret := os.Getenv("CLIENT_SECRET")
+	oauthURL := "https://slack.com/api/oauth.v2.access"
+	form := url.Values{}
+	form.Add("code", code)
+	form.Add("client_id", clientID)
+	form.Add("client_secret", clientSecret)
+	resp, err := http.Post(
+		oauthURL,
+		"application/x-www-form-urlencoded",
+		strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		log.Println(err)
 	}
-	return resp, nil
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+	log.Printf("%s", body)
+	var oauthAccessResponse OauthAccessResponse;
+	unMarshallErr := json.Unmarshal(body, &oauthAccessResponse)
+	if unMarshallErr != nil {
+		log.Println(unMarshallErr)
+	}
+	log.Println(oauthAccessResponse)
+	botAccessToken := oauthAccessResponse.AccessToken
+	log.Println(botAccessToken)
+	redirectURL := "https://app.slack.com/client/" + oauthAccessResponse.Team.ID
+	response := Response{
+		StatusCode: 302,
+		Headers: map[string]string{
+			"Location": redirectURL,
+		},
+		Body: "",
+	}
+	return response, nil
 }
 
 func main() {

--- a/messages/service.go
+++ b/messages/service.go
@@ -21,10 +21,6 @@ import (
 var slackBotUserOauthToken = os.Getenv("SLACK_BOT_USER_OAUTH_ACCESS_TOKEN")
 var slackBotUserApiClient = slack.New(slackBotUserOauthToken)
 
-// If you need anything else, use this client instead
-// var slackOauthToken = os.Getenv("SLACK_OAUTH_ACCESS_TOKEN")
-// var slackRegularApiClient = slack.New(slackOauthToken)
-
 // ParseEvent is the assignation of slackevents.ParseEvent to a variable,
 // in order to make it mockable
 var parseEvent = slackevents.ParseEvent

--- a/serverless.yml
+++ b/serverless.yml
@@ -49,7 +49,6 @@ functions:
     environment:
       PD_API_URL: ${self:custom.secrets.PD_API_URL}
       PD_API_KEY: ${self:custom.secrets.PD_API_KEY}
-      SLACK_OAUTH_ACCESS_TOKEN: ${self:custom.secrets.SLACK_OAUTH_ACCESS_TOKEN}
       SLACK_BOT_USER_OAUTH_ACCESS_TOKEN: ${self:custom.secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN}
       SLACK_VERIFICATION_TOKEN: ${self:custom.secrets.SLACK_VERIFICATION_TOKEN}
   dynamodbExample:

--- a/serverless.yml
+++ b/serverless.yml
@@ -64,3 +64,6 @@ functions:
       - http:
           path: redirect-url
           method: get
+    environment:
+      CLIENT_ID: ${self:custom.secrets.CLIENT_ID}
+      CLIENT_SECRET: ${self:custom.secrets.CLIENT_SECRET}

--- a/serverless.yml
+++ b/serverless.yml
@@ -58,3 +58,9 @@ functions:
       - http:
           path: dynamodb-example
           method: get
+  redirectUrl:
+    handler: bin/redirectUrl
+    events:
+      - http:
+          path: redirect-url
+          method: get


### PR DESCRIPTION
- Implement Oauth permissions
- Store bot access token in DynamoDB
- Add CLIENT_ID and CLIENT_SECRET to the config
- Remove unused SLACK_OAUTH_ACCESS_TOKEN